### PR TITLE
pc - add github workflow to publish sphinx docs

### DIFF
--- a/.github/workflows/make-sphinx-docs.yml
+++ b/.github/workflows/make-sphinx-docs.yml
@@ -1,0 +1,27 @@
+name: "Make Sphinx Docs"
+on: 
+- workflow_dispatch
+- pull_request
+
+jobs:    
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"
+    # We need a .nojekyll file in the root of the gh-pages branch
+    # to prevent GitHub from ignoring files that begin with an underscore
+    # See: https://help.github.com/en/articles/files-that-start-with-an-underscore-are-missing
+    # Also: 
+    # - name: Add .nojekyll file
+    #   run: |
+    #     sudo touch docs/build/html/.nojekyll
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages # The branch the action should deploy to.
+        folder: docs/build/html
+        clean: true # Automatically remove deleted files from the deploy branch
+    

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,7 @@
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -141,7 +142,7 @@ def setup(app):
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
In this PR, we add a github workflow to create the Sphinx documentation.  The intention is to eventually publish this to github pages.